### PR TITLE
Fix naming conflict in bulma sass

### DIFF
--- a/assets/bulma/sass/helpers/flexbox.sass
+++ b/assets/bulma/sass/helpers/flexbox.sass
@@ -1,6 +1,3 @@
-.is-flex
-  display: flex !important
-
 $flex-direction-values: row, row-reverse, column, column-reverse
 @each $value in $flex-direction-values
   .is-flex-direction-#{$value}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,10 +1,10 @@
 {{ define "main" }}
 
-<!-- top bar headline, needs diff color background -->
-<section class="section p-1 has-background-white-ter border-b-1">
+<!-- top bar headline, needs diff color background, hidden on tablet/mobile -->
+<section class="section p-2 has-background-white-ter border-y-1 is-hidden-touch">
   <div class="container">
     <div class="columns has-text-centered is-align-items-center">
-      <div class="column is-flex is-flex-direction-row is-justify-content-space-between is-align-items-center">
+      <div class="column is-flex-tablet is-flex-direction-row is-justify-content-space-between is-align-items-center">
         <span class="icon is-large">
           <i class="fa fa-3x fa-newspaper-o"></i>
         </span>


### PR DESCRIPTION
There was already an option to force `display:flex` in responsive helpers, removed my variant in flexbox and modified breaking news to hide on mobile.