### PR TITLE
Add coinmarketcap api

### DIFF
--- a/.github/workflows/cf-deploy-prod.yml
+++ b/.github/workflows/cf-deploy-prod.yml
@@ -22,6 +22,8 @@ jobs:
           extended: true
 
       - name: Build Site
+        env:
+          CMC_API: ${{ secrets.CMC_API }}
         run: hugo
 
       - name: Publish CF

--- a/.github/workflows/cf-deploy-prod.yml
+++ b/.github/workflows/cf-deploy-prod.yml
@@ -27,7 +27,7 @@ jobs:
         run: hugo
 
       - name: Publish CF
-        uses: cloudflare/wrangler-action@1.2.0
+        uses: cloudflare/wrangler-action@1.3.0
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           environment: 'production'

--- a/.github/workflows/cf-deploy-test.yml
+++ b/.github/workflows/cf-deploy-test.yml
@@ -27,6 +27,6 @@ jobs:
         run: hugo
 
       - name: Publish CF
-        uses: cloudflare/wrangler-action@1.2.0
+        uses: cloudflare/wrangler-action@1.3.0
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}

--- a/.github/workflows/cf-deploy-test.yml
+++ b/.github/workflows/cf-deploy-test.yml
@@ -22,6 +22,8 @@ jobs:
           extended: true 
 
       - name: Build Site
+        env:
+          CMC_API: ${{ secrets.CMC_API }}
         run: hugo
 
       - name: Publish CF

--- a/assets/unmuteable.scss
+++ b/assets/unmuteable.scss
@@ -5,6 +5,7 @@ $black: #191D26;
 $red: #CC0000;
 $yellow: #CCCC00;
 $green: #00CC00;
+$grey-lightest: hsl(0, 0%, 93%);
 $link: $primary;
 $link-visited: $primary;
 $link-hover: $black;
@@ -15,6 +16,8 @@ $family-secondary: Manrope-ExtraBold, Arial, sans-serif;
 $navbar-item-hover-color: $primary !important;
 $navbar-dropdown-item-hover-color: $primary;
 $navbar-dropdown-item-hover-background-color: $black;
+$card-shadow: 5px 5px 0px 0px $black, -5px -5px 0px 0px $primary;
+$card-header-shadow: none;
 
 // Some slight CSS adjustments
 .hero-img { max-width: 90vw; }

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -143,8 +143,8 @@ https://stackoverflow.com/questions/41709977/bulma-change-stack-order-of-columns
           </div>
         </div>
       </div>
-      <div class="column has-background-grey-lighter">
-        Aside content for a featured category, test with zero to testnet series.
+      <div class="column is-flex-desktop is-flex-direction-column is-justify-content-center">
+        {{- partial "cmc_api.html" . -}}
       </div>
     </div>
   </div>
@@ -178,7 +178,8 @@ https://stackoverflow.com/questions/41709977/bulma-change-stack-order-of-columns
   </div>
 </section>
 
-<!-- section for remaining articles + aside -->
+<!-- section for remaining articles + aside
+  TO BE USED LATER WHEN WE HAVE MORE CONTENT :)
 <section class="section border-b-1">
   <div class="container">
     <div class="columns">
@@ -186,10 +187,11 @@ https://stackoverflow.com/questions/41709977/bulma-change-stack-order-of-columns
         Space for remaining articles, can be listed as full-row items that will fold above the aside content.
       </div>
       <div class="column has-background-grey-lighter">
-        Aside for prices and whatnot, have coinmarketcap api just need to use it!
+        {{- partial "cmc_api.html" . -}}
       </div>
     </div>
   </div>
 </section>
+-->
 
 {{ end }}

--- a/layouts/partials/cmc_api.html
+++ b/layouts/partials/cmc_api.html
@@ -1,0 +1,59 @@
+{{ $cmcAPIKey := getenv "CMC_API" }}
+{{ if ne $cmcAPIKey "" }}
+
+  <!-- API Key Detected! -->
+
+  {{ $cmcURL := newScratch }}
+  {{ $cmcURL.Add "url" "https://pro-api.coinmarketcap.com/v1/cryptocurrency/quotes/latest?CMC_PRO_API_KEY=" }}
+  {{ $cmcURL.Add "url" $cmcAPIKey }}
+  {{ $cmcURL.Add "url" "&id=1" }}
+  {{ $cmcURL.Add "url" ",4847" }}
+  {{ $cmcData := getJSON ($cmcURL.Get "url") }}
+
+  <article class="message is-dark border-1">
+    <div class="message-header has-text-centered">Market Prices</div>
+    <div class="message-body my-2">
+      {{ range $cmcData.data }}
+        <div class="card mb-4">
+          <header class="card-header border-b-1">
+            <p class="card-header-title is-hidden-tablet-only is-justify-content-center">
+              {{ .name }}
+            </p>
+            <p class="card-header-title is-hidden-mobile is-hidden-desktop is-justify-content-center">
+              {{ .symbol }}
+            </p>
+          </header>
+          <div class="card-content is-display-flex">
+            <div class="columns is-mobile">
+              <div class="column is-hidden-tablet-only has-text-right">
+                <p>Price:</p>
+                <p>24hr:</p>
+                <p>7day:</p>
+              </div>
+              {{ $priceChange24h := printf "%.2f" .quote.USD.percent_change_24h }}
+              {{ $priceChange7d := printf "%.2f" .quote.USD.percent_change_7d }}
+              <div class="column">
+                <p>${{ printf "%.2f" .quote.USD.price }}</p>
+                <p>{{ if gt $priceChange24h 0 }}+{{ end }}{{ $priceChange24h }}%</p>
+                <p>{{ if gt $priceChange7d 0 }}+{{ end }}{{ $priceChange7d }}%</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      {{ end }}
+    </div>
+  </article>
+
+{{ else }}
+
+  <article class="message is-dark">
+    <div class="message-header">
+      <p>Unable to load API</p>
+    </div>
+    <div class="message-body">
+      Unfortunately, we cannot connect to the price API at this time. Please refresh the page or check again later.
+    </div>
+  </article>
+
+{{ end }}
+


### PR DESCRIPTION
This PR adds a template partial for the coinmarketcap api, and uses a github secret to store and retrieve the key. 

Market prices are displayed in an aside field to the content that folds under. 

It also eliminates the bottom section on favor of adding it back when we have more content.