### PR TITLE
Fix valid html and add responsive images

### DIFF
--- a/assets/unmuteable.scss
+++ b/assets/unmuteable.scss
@@ -23,6 +23,17 @@ $card-header-shadow: none;
 .hero-img { max-width: 90vw; }
 .hero-img-post { max-width: 50vw; }
 .hero-img-list { max-width: 100%; }
+.header-link,
+.header-link:visited {
+  color: $black;
+}
+.header-link:hover,
+.header-link:active {
+  color: $primary;
+}
+.header-link:hover span {
+  display: inline !important;
+}
 .category-button:hover { 
   color: $primary !important;
   border-color: $primary !important;

--- a/content/blog/A-Truly-Forgettable-User-Experience/index.md
+++ b/content/blog/A-Truly-Forgettable-User-Experience/index.md
@@ -4,6 +4,7 @@ title: "A Truly Forgettable User Experience"
 date: "2020-02-24"
 draft: false
 description: "Remembering login info is hard." 
+img_cover: "cover.png"
 categories:
 - Stacks 
 - UI/UX

--- a/content/blog/Blockstack-How-to-git-Involved/index.md
+++ b/content/blog/Blockstack-How-to-git-Involved/index.md
@@ -4,6 +4,7 @@ title: "Blockstack: How to -git- Involved"
 date: 2020-03-09
 draft: false
 description: "Working with Blockstack and GitHub"
+img_cover: "cover.png"
 categories:
 - Stacks
 - GitHub

--- a/content/blog/Decoding-Discord-Chats-and-Hangouts/index.md
+++ b/content/blog/Decoding-Discord-Chats-and-Hangouts/index.md
@@ -11,6 +11,10 @@ categories:
 
 Trying new things is hard, and learning them on the fly during a presentation in front of an audience is even harder.
 
+![Video Sharing Screenshot](20200910_007_Selection.png "Video Sharing Screenshot Title")
+
 Below is a comprehensive walkthrough of some basic Discord chat functions, tailored specifically toward the Stacks hangouts that happen in the community channel.
+
+![Community Voice Channel](20200910_001_Selection.png "Community Voice Channel Title")
 
 The original content is hosted on Sigle, [read more here!](https://app.sigle.io/whoabuddy.id.blockstack/IFT64oGIRG6yvFF4LB0UW)

--- a/content/blog/Decoding-Discord-Chats-and-Hangouts/index.md
+++ b/content/blog/Decoding-Discord-Chats-and-Hangouts/index.md
@@ -4,6 +4,7 @@ title: "Decoding Discord Chats and Hangouts"
 date: "2020-09-09"
 draft: false
 description: "Discord Tips and Tricks"
+img_cover: "cover.png"
 categories:
 - Discord
 - Training

--- a/content/blog/Defining-DeFi-on-BTC-with-Clarity-and-Stacks-2.0/index.md
+++ b/content/blog/Defining-DeFi-on-BTC-with-Clarity-and-Stacks-2.0/index.md
@@ -4,6 +4,7 @@ title: "Defining DeFi on BTC with Clarity and Stacks 2.0"
 date: "2020-10-10"
 draft: false
 description: "DeFi backed by Bitcoin"
+img_cover: "cover.png"
 categories:
 - Freehold
 - Stacks

--- a/content/blog/First-Ever-STX-Mining-Competition-Experience/index.md
+++ b/content/blog/First-Ever-STX-Mining-Competition-Experience/index.md
@@ -4,6 +4,7 @@ title: "First Ever STX Mining Competition Experience"
 date: "2020-11-05"
 draft: false
 description: "Mining on Stacks 2.0"
+img_cover: "cover.png"
 categories:
 - Freehold
 - Stacks

--- a/content/blog/Zero-to-Testnet-Step-0/index.md
+++ b/content/blog/Zero-to-Testnet-Step-0/index.md
@@ -4,6 +4,7 @@ title: "Zero to Testnet: Step 0"
 date: "2020-05-05"
 draft: false
 description: "Step 0: Virtualbox and Ubuntu" 
+img_cover: "cover.png"
 categories:
 - Zero-to-Testnet
 - Stacks

--- a/content/blog/Zero-to-Testnet-Step-1/index.md
+++ b/content/blog/Zero-to-Testnet-Step-1/index.md
@@ -4,6 +4,7 @@ title: "Zero to Testnet: Step 1"
 date: "2020-05-12"
 draft: false
 description: "Step 1: Follower Node"
+img_cover: "cover.png"
 categories:
 - Zero-to-Testnet
 - Stacks

--- a/content/blog/Zero-to-Testnet-Step-2/index.md
+++ b/content/blog/Zero-to-Testnet-Step-2/index.md
@@ -4,6 +4,7 @@ title: "Zero to Testnet: Step 2"
 date: "2020-05-19"
 draft: false
 description: "Step 2: Miner Node"
+img_cover: "cover.png"
 categories:
 - Zero-to-Testnet
 - Stacks

--- a/content/blog/markdown-syntax-guide/index.md
+++ b/content/blog/markdown-syntax-guide/index.md
@@ -4,6 +4,7 @@ title: "Markdown Syntax Guide"
 date: "2020-05-01"
 draft: true
 description: "Markdown syntax examples" 
+img_cover: "cover.png"
 categories:
 - syntax 
 - markdown

--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -1,0 +1,9 @@
+<h{{ .Level }} id="{{ .Anchor | safeURL }}">
+  <a href="#{{ .Anchor | safeURL }}"
+    class="header-link">
+    {{ .Text | safeHTML }}
+    <span class="icon pl-1 is-hidden">
+      <i class="fa fa-link" aria-hidden="true"></i>
+    </span></h{{ .Level }}>
+  </a>
+</h{{ .Level }}>

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,0 +1,29 @@
+{{ $image := .Page.Resources.GetMatch (printf "%s" (.Destination | safeURL)) }}
+{{ $mobile := $image.Resize "768x" }}
+{{ $tablet := $image.Resize "1024x" }}
+{{ $desktop := $image.Resize "1216x" }}
+{{ $alt := .PlainText | safeHTML }}
+{{ $caption := "" }}
+{{ with .Title }}
+  {{ $caption = . | safeHTML }}
+{{ end }}
+
+<figure>
+  <a href="{{ $image.RelPermalink }}">
+    <img
+      sizes="100vw"
+      srcset="{{ $mobile.RelPermalink }} 768w,
+        {{ $tablet.RelPermalink }} 1024w,
+        {{ $desktop.RelPermalink }} 1216w"
+      src="{{ $image.RelPermalink }}"
+      width="{{ $image.Width }}"
+      height="{{ $image.Height }}"
+      alt="{{ if $alt }}{{ $alt }}
+        {{ else if $caption }}{{ $caption | markdownify | plainify }}
+        {{ else }}&nbsp;{{ end }}"
+      />
+  </a>
+  {{ with $caption }}
+    <figcaption>{{ . | markdownify }}</figcaption>
+  {{ end }}
+</figure>

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,6 @@
+
+<a href="{{ .Destination | safeURL }}"
+  {{ with .Title}} title="{{ . }}"{{ end }}
+  {{ if strings.HasPrefix .Destination "http" }} target="_blank" rel="noopener"{{ end }}>
+  {{ .Text | safeHTML }}
+</a>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -19,12 +19,11 @@
         </h1>
       </div>
       <div class="column">
-        {{ with .Resources.Match "cover.png" }}
-          {{ range . }}
-            <img src="{{ .RelPermalink }}"
-              alt="Cover image for post, will need ALT TEXT eventually." />
-          {{ end }}
-        {{ end }}
+        {{ $image := .Resources.GetMatch (printf "%s" "cover.png") }}
+        {{ $mobile := $image.Resize "768x" }}
+        {{ $tablet := $image.Resize "1024x" }}
+        {{ $desktop := $image.Resize "1216x" }}
+        {{- partial "cover-image.html" (dict "img" $image.RelPermalink "img_alt" .Description "mobile" $mobile.RelPermalink "tablet" $tablet.RelPermalink "desktop" $desktop.RelPermalink) -}}
       </div>
       {{ end }}
     </div>
@@ -54,12 +53,11 @@ https://stackoverflow.com/questions/41709977/bulma-change-stack-order-of-columns
           </div>
         </div>
         <div class="column">
-          {{ with .Resources.Match "cover.png" }}
-            {{ range . }}
-              <img src="{{ .RelPermalink }}"
-                alt="Cover image for post, will need ALT TEXT eventually." />
-            {{ end }}
-          {{ end }}
+          {{ $image := .Resources.GetMatch (printf "%s" "cover.png") }}
+        {{ $mobile := $image.Resize "768x" }}
+        {{ $tablet := $image.Resize "1024x" }}
+        {{ $desktop := $image.Resize "1216x" }}
+        {{- partial "cover-image.html" (dict "img" $image.RelPermalink "img_alt" .Description "mobile" $mobile.RelPermalink "tablet" $tablet.RelPermalink "desktop" $desktop.RelPermalink) -}}
         </div>
       {{ end }}
     </div>    
@@ -96,12 +94,11 @@ https://stackoverflow.com/questions/41709977/bulma-change-stack-order-of-columns
         <div class="columns">
           <div class="column is-two-thirds">
             {{ range ( first 1 (after 1 ( where .Site.Pages "Type" "blog" )).ByPublishDate.Reverse ) }}
-              {{ with .Resources.Match "cover.png" }}
-                {{ range . }}
-                  <img src="{{ .RelPermalink }}"
-                    alt="Cover image for post, will need ALT TEXT eventually." />
-                {{ end }}
-              {{ end }}
+              {{ $image := .Resources.GetMatch (printf "%s" "cover.png") }}
+              {{ $mobile := $image.Resize "768x" }}
+              {{ $tablet := $image.Resize "1024x" }}
+              {{ $desktop := $image.Resize "1216x" }}
+              {{- partial "cover-image.html" (dict "img" $image.RelPermalink "img_alt" .Description "mobile" $mobile.RelPermalink "tablet" $tablet.RelPermalink "desktop" $desktop.RelPermalink) -}}
               <div class="tags">
                 {{ range .Params.categories }}
                     <a class="tag is-primary is-medium" href="{{ "/categories/" | relLangURL }}{{ . | urlize }}" title="{{ . }}">{{ . }}</a>
@@ -120,12 +117,11 @@ https://stackoverflow.com/questions/41709977/bulma-change-stack-order-of-columns
             <div class="columns is-flex-direction-column">
               {{ range ( first 2 (after 1 ( where .Site.Pages "Type" "blog" )).ByPublishDate.Reverse ) }}
                 <div class="column">
-                  {{ with .Resources.Match "cover.png" }}
-                    {{ range . }}
-                      <img src="{{ .RelPermalink }}"
-                        alt="Cover image for post, will need ALT TEXT eventually." />
-                    {{ end }}
-                  {{ end }}
+                  {{ $image := .Resources.GetMatch (printf "%s" "cover.png") }}
+                  {{ $mobile := $image.Resize "768x" }}
+                  {{ $tablet := $image.Resize "1024x" }}
+                  {{ $desktop := $image.Resize "1216x" }}
+                  {{- partial "cover-image.html" (dict "img" $image.RelPermalink "img_alt" .Description "mobile" $mobile.RelPermalink "tablet" $tablet.RelPermalink "desktop" $desktop.RelPermalink) -}}
                   <div class="tags">
                     {{ range .Params.categories }}
                         <a class="tag is-primary" href="{{ "/categories/" | relLangURL }}{{ . | urlize }}" title="{{ . }}">{{ . }}</a>
@@ -156,12 +152,11 @@ https://stackoverflow.com/questions/41709977/bulma-change-stack-order-of-columns
     <div class="columns">
       {{ range ( first 3 (after 1 ( where .Site.Pages "Type" "blog" )).ByPublishDate.Reverse ) }}
         <div class="column">
-          {{ with .Resources.Match "cover.png" }}
-            {{ range . }}
-              <img src="{{ .RelPermalink }}"
-                alt="Cover image for post, will need ALT TEXT eventually." />
-            {{ end }}
-          {{ end }}
+          {{ $image := .Resources.GetMatch (printf "%s" "cover.png") }}
+          {{ $mobile := $image.Resize "768x" }}
+          {{ $tablet := $image.Resize "1024x" }}
+          {{ $desktop := $image.Resize "1216x" }}
+          {{- partial "cover-image.html" (dict "img" $image.RelPermalink "img_alt" .Description "mobile" $mobile.RelPermalink "tablet" $tablet.RelPermalink "desktop" $desktop.RelPermalink) -}}
           <div class="tags">
             {{ range .Params.categories }}
                 <a class="tag is-primary" href="{{ "/categories/" | relLangURL }}{{ . | urlize }}" title="{{ . }}">{{ . }}</a>

--- a/layouts/partials/cmc_api.html
+++ b/layouts/partials/cmc_api.html
@@ -11,7 +11,9 @@
   {{ $cmcData := getJSON ($cmcURL.Get "url") }}
 
   <article class="message is-dark border-1">
-    <div class="message-header has-text-centered">Market Prices</div>
+    <div class="message-header">
+      <h3 class="">Market Prices</h3>
+    </div>
     <div class="message-body my-2">
       {{ range $cmcData.data }}
         <div class="card mb-4">
@@ -48,7 +50,7 @@
 
   <article class="message is-dark">
     <div class="message-header">
-      <p>Unable to load API</p>
+      <h3>Unable to load API</h3>
     </div>
     <div class="message-body">
       Unfortunately, we cannot connect to the price API at this time. Please refresh the page or check again later.

--- a/layouts/partials/cover-image.html
+++ b/layouts/partials/cover-image.html
@@ -1,0 +1,10 @@
+<figure>
+  <img
+    sizes="100vw"
+    srcset="{{ .mobile }} 768w,
+      {{ .tablet }} 1024w,
+      {{ .desktop }} 1216w"
+    src="{{ .img }}"
+    alt="{{ .img_alt }}"
+    />
+</figure>


### PR DESCRIPTION
This PR contains a few new features:
- adds headings to cmc_api partial to satisfy NuHtml validator errors
- markdown render hook for external links and image processing
- markdown render hook for responsive images in articles
- markdown render hook for heading links
- adds new front matter to each post defining cover image
- creates and implements partial for cover images on index

fixes #33
fixes #35
fixes #36